### PR TITLE
Ingest and Metadata Display working like a charm

### DIFF
--- a/ami.services.yml
+++ b/ami.services.yml
@@ -5,6 +5,6 @@ services:
     arguments: ['@entity_type.manager']
   ami.utility:
     class: Drupal\ami\AmiUtilityService
-    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility', '@entity_field.manager', '@entity_type.bundle.info']
+    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility', '@entity_field.manager', '@entity_type.bundle.info', '@http_client']
     tags:
       - { name: backend_overridable }

--- a/src/Form/AmiMultiStepIngestBaseForm.php
+++ b/src/Form/AmiMultiStepIngestBaseForm.php
@@ -178,9 +178,7 @@ class AmiMultiStepIngestBaseForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    dpm($form_state->getValues());
     if ($form_state->getTriggeringElement()['#name'] == 'prev') {
-      error_log('called prev');
       $this->step--;
     } else {
       $this->step++;
@@ -193,8 +191,7 @@ class AmiMultiStepIngestBaseForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    dpm($form_state->getTriggeringElement()['#ajax']);
-    error_log('validateForm');
+
     if ($form_state->getTriggeringElement()['#name'] == 'prev') {
       // No validation my friends.
     } else {

--- a/src/Plugin/Action/AmiStrawberryfieldJsonAsWebform.php
+++ b/src/Plugin/Action/AmiStrawberryfieldJsonAsWebform.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Drupal\ami\Plugin\Action;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\HtmlCommand;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\views\ViewExecutable;
+use Drupal\webform\Plugin\WebformElement\WebformManagedFileBase;
+use Drupal\webform\Plugin\WebformElementEntityReferenceInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+
+/**
+ * Provides an action that can Modify Entity attached SBFs via JSON Patch.
+ *
+ * @Action(
+ *   id = "entity:ami_jsonwebform_action",
+ *   action_label = @Translation("Webform based find and replace Metadata for Archipelago Digital Objects"),
+ *   category = @Translation("AMI Metadata"),
+ *   deriver = "Drupal\Core\Action\Plugin\Action\Derivative\EntityChangedActionDeriver",
+ *   type = "node",
+ *   confirm = "true"
+ * )
+ */
+class AmiStrawberryfieldJsonAsWebform extends AmiStrawberryfieldJsonAsText {
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+  /**
+   * The webform element manager.
+   *
+   * @var \Drupal\webform\Plugin\WebformElementManagerInterface
+   */
+  protected $webformElementManager;
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->AmiUtilityService = $container->get('ami.utility');
+    $instance->webformElementManager = $container->get('plugin.manager.webform.element');
+    return $instance;
+
+  }
+
+  public function buildPreConfigurationForm(array $element, array $values, FormStateInterface $form_state) {
+    dpm('pre');
+  }
+
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $webform = $this->AmiUtilityService->getWebforms();
+    error_log('building!');
+    error_log(var_export($form_state->getValue(['elements_rendered','jsonfind_element']),true));
+    $form_state->disableCache();
+    $form['#tree'] = TRUE;
+    $form['webform'] =[
+      '#type' => 'select',
+      '#title' => $this->t('Select which Webform you want to use'),
+      '#options' => $webform,
+      '#default_value' => $form_state->getValue('webform')? $form_state->getValue('webform') : NULL,
+      '#empty_option' => $this->t('- Please select a webform -'),
+      '#ajax' => array(
+        'callback' => [$this, 'webformAjaxCallback'],
+        'wrapper' => 'webform-elements-wrapper',
+        'event' => 'change',
+      ),
+    ];
+
+    $form['webform_elements'] = [
+      '#tree' => TRUE,
+      '#type' => 'container',
+      '#prefix' => '<div id="webform-elements-wrapper">',
+      '#suffix' => '</div>',
+    ];
+    $form['elements_rendered'] = [
+      '#tree' => TRUE,
+      '#type' => 'fieldset',
+      '#prefix' => '<div id="webform-elements-render-wrapper">',
+      '#suffix' => '</div>',
+    ];
+    $webform_element_options = [];
+    dpm($form_state->getValues());
+    $webform_entity = NULL;
+    if (!empty($form_state->getValues()) && !empty($form_state->getValue('webform'))) {
+      /* @var \Drupal\webform\Entity\Webform $webform_entity */
+      $webform_entity = $this->entityTypeManager->getStorage('webform')->load($form_state->getValue('webform'));
+      $anyelement = $webform_entity->getElementsInitializedAndFlattened();
+      foreach ($anyelement as $elementkey => $element) {
+        $element_plugin = $this->webformElementManager->getElementInstance($element);
+        if (($element_plugin->getTypeName() != 'webform_wizard_page') && !($element_plugin instanceof WebformManagedFileBase)) {
+          $webform_element_options[$elementkey] = $element['#title'];
+        }
+      }
+      //dpm($webform_entity->getElementsDecodedAndFlattened());
+        //dpm($webform_entity->getElementInitialized($form_state->getValue('elements')));
+        //$form['webform_elements']['elements_render']['jsonfind2']= $webform_entity->getElementInitialized($form_state->getValue('elements'));
+    }
+    $form['webform_elements']['elements_for_this_form'] = [
+      '#type' => 'select',
+      // If not #validated, dynamically populated select options don't work.
+      '#validated' => TRUE,
+      '#title' => $this->t('Select which Form Element you want to use'),
+      '#options' => count($webform_element_options) ? $webform_element_options:  [],
+      '#default_value' => NULL,
+      '#submit' => [[$this, 'field_submit']],
+      '#executes_submit_callback' => TRUE,
+      '#empty_option' => $this->t('- Please select an element -'),
+      '#ajax' => array(
+        'callback' => [get_class($this),'webformElementAjaxCallback'],
+        'wrapper' => 'webform-elements-render-wrapper',
+        'event' => 'change',
+      ),
+    ];
+    dpm($form_state->getValues());
+    dpm($form_state->getValue(['webform_elements,elements_for_this_form']));
+    if ($webform_entity && $form_state->getValue(['webform_elements','elements_for_this_form'])){
+       $myelement = $webform_entity->getElement($form_state->getValue(['webform_elements','elements_for_this_form']));
+       $cleanelement = [];
+       foreach($myelement as $key => $value) {
+          if (strpos($key, '#webform') === FALSE && strpos($key, '#access_') === FALSE) {
+            $cleanelement[$key] = $value;
+          }
+       }
+       $cleanelement['#element_validate'][] = [get_class($this),'elementDynamicValidate'];
+       $cleanelement['#required'] = FALSE;
+       $cleanelement['#validated'] = FALSE;
+       $cleanelement['#default_value'] = NULL;
+       $cleanelement['#submit'] = [[$this, 'dynamic_field_submit']];
+       $cleanelement['#executes_submit_callback'] = TRUE;
+       $form['elements_rendered']['jsonfind_element']= $cleanelement;
+       dpm($form['elements_rendered']['jsonfind_element']);
+    }
+
+    $form['jsonfind'] = [
+      '#type' => 'textfield',
+      '#title' => t('JSON Search String'),
+      '#default_value' => $this->configuration['jsonfind'],
+      '#size' => '40',
+      '#description' => t('A string you want to find inside your JSON.'),
+    ];
+    $form['jsonreplace'] = [
+      '#type' => 'textfield',
+      '#title' => t('JSON Replacement String'),
+      '#default_value' => $this->configuration['jsonreplace'],
+      '#size' => '40',
+      '#description' => t('Replacement string for the matched search'),
+    ];
+
+    $form['simulate'] = [
+      '#title' => $this->t('only simulate and debug affected JSON'),
+      '#type' => 'checkbox',
+      '#default_value' => ($this->configuration['simulate'] === FALSE) ? FALSE : TRUE,
+    ];
+    return $form;
+  }
+
+  /**
+   * Submission handler for condition changes in
+   */
+  public function field_submit(array &$form, FormStateInterface $form_state) {
+
+    error_log('calling field_submit');
+
+
+    if (empty($form_state->getValue('webform'))) {
+      error_log('webform is empty');
+      $form_state->unsetValue(['webform_elements','elements_for_this_form']);
+    }
+    if (empty($form_state->getValue(['webform_elements','elements_for_this_form']))) {
+
+    }
+    // We have to unset this is a form element's needed value may not match
+    // a new one's need. E.g textfield v/s entity autocomplete
+    error_log('skipping unsettting');
+    //$form_state->unsetValue(['elements_rendered','jsonfind_element']);
+    $form_state->setRebuild(TRUE);
+  }
+  /**
+   * Submission handler for condition changes in
+   */
+  public function dynamic_field_submit(array &$form, FormStateInterface $form_state) {
+
+    error_log('dynamic_field_submit');
+  }
+
+  public static function elementDynamicValidate(&$element, FormStateInterface $form_state) {
+    error_log('calling elementDynamicValidate');
+
+    //$element['#value'] = array_filter($element['#value']);
+    error_log(var_export($element,true));
+    error_log(var_export($form_state->getValue('elements_rendered'),true));
+    $form_state->set('holi','chao');
+   // $form_state->setValueForElement($element, $element['#value']);
+    error_log('Setting value');
+  }
+
+  public function webformAjaxCallback(array $form, FormStateInterface $form_state) {
+    return $form['webform_elements'];
+  }
+  public static function webformElementAjaxCallback(array $form, FormStateInterface $form_state) {
+    return $form['elements_rendered'];
+    /*$item = [
+      '#type' => 'item',
+      '#title' => $this->t('Ajax value'),
+      '#markup' => microtime(),
+    ];
+    $response = new AjaxResponse();
+    $response->addCommand(new HtmlCommand('#form-elements-render-wrapper', $item));
+    return $response;*/
+  }
+
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    dpm($form_state->getValues());
+    $this->configuration['jsonfind'] = $form_state->getValue('jsonfind');
+    $this->configuration['jsonreplace'] = $form_state->getValue('jsonreplace');
+    $this->configuration['simulate'] = $form_state->getValue('simulate');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'jsonfind' => '',
+      'jsonreplace' => '',
+      'simulate' => TRUE,
+    ];
+  }
+
+  /**
+   * Default custom access callback.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user the access check needs to be preformed against.
+   * @param \Drupal\views\ViewExecutable $view
+   *   The View Bulk Operations view data.
+   *
+   * @return bool
+   *   Has access.
+   */
+  public static function customAccess(AccountInterface $account, ViewExecutable $view) {
+    return TRUE;
+  }
+
+
+
+
+}

--- a/src/Plugin/ImporterAdapterBase.php
+++ b/src/Plugin/ImporterAdapterBase.php
@@ -37,7 +37,7 @@ abstract class ImporterAdapterBase extends PluginBase implements ImporterPluginA
   protected $entityTypeManager;
 
   /**
-   * @var \GuzzleHttp\Client
+   * @var \GuzzleHttp\ClientInterface
    */
   protected $httpClient;
 

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ami\Plugin\QueueWorker;
 
+use Drupal\ami\AmiUtilityService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -15,8 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @QueueWorker(
  *   id = "ami_ingest_ado",
- *   title = @Translation("AMI Digital Object Ingester Queue Worker"),
- *   cron = {"time" = 5}
+ *   title = @Translation("AMI Digital Object Ingester Queue Worker")
  * )
  */
 class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
@@ -42,6 +42,13 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
    */
   protected $strawberryfieldUtility;
 
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+
   /**
    * Constructor.
    *
@@ -56,12 +63,14 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldUtilityService $strawberryfield_utility_service
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+    AmiUtilityService $ami_utility
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
     $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->AmiUtilityService = $ami_utility;
   }
 
   /**
@@ -86,7 +95,8 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('logger.factory'),
-      $container->get('strawberryfield.utility')
+      $container->get('strawberryfield.utility'),
+      $container->get('ami.utility')
     );
   }
 
@@ -94,39 +104,142 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public function processItem($data) {
+
+    // Before we do any processing. Check if Parent(s) exists?
+    // If not, re-enqueue: we try twice only. Should we try more?
+    if (isset($data->info['row']['parent']) && is_array($data->info['row']['parent'])) {
+      $parents = array_values($data->info['row']['parent']);
+      $parents = array_filter($parents);
+      error_log('We got parents, checking if they exist');
+      error_log(var_export($parents,true));
+      foreach($parents as $parent_uuid) {
+        error_log(var_export($parent_uuid,true));
+        $parent_uuids = (array) $parent_uuid;
+        $existing = $this->entityTypeManager->getStorage('node')->loadByProperties(['uuid' => $parent_uuids]);
+        if (count($existing) != count($parent_uuids)) {
+          error_log('Sorry, we can not process this one yet, there are missing parents');
+          // Pushing to the end of the queue.
+          $data->info['attempt']++;
+          if ($data->info['attempt'] < 3) {
+            error_log('Re-enqueueing');
+            \Drupal::queue('ami_ingest_ado')
+              ->createItem($data);
+            return;
+          } else {
+            error_log('WE tried twice. Will not re-enqueue');
+            return;
+            // We could enqueue in a "failed" queue?
+          }
+        }
+      }
+    }
+
+    $processed_metadata = $this->AmiUtilityService->processMetadataDisplay($data);
+    $cleanvalues = [];
+    // Now process Files and Nodes
+    $ado_columns = array_values(get_object_vars($data->adomapping->parents));
+    if ($data->mapping->globalmapping == "custom") {
+      $file_columns = array_values(get_object_vars($data->mapping->custommapping_settings->{$data->info['row']['type']}->files));
+    }
+    else
+    {
+      $file_columns = array_values(get_object_vars($data->mapping->globalmapping_settings->files));
+    }
+
+    $entity_mapping_structure['entity:file'] = $file_columns;
+    $entity_mapping_structure['entity:node'] =  $ado_columns;
+    $processed_metadata = json_decode($processed_metadata, true);
+    $cleanvalues["ap:entitymapping"] = $entity_mapping_structure;
+    $processed_metadata  = $processed_metadata + $cleanvalues;
+    error_log(var_export($processed_metadata,true));
+    // Now do heavy file lifting
+    foreach($file_columns as $file_column) {
+      // Why 5? one character + one dot + 3 for the extension
+      if (isset($data->info['row']['data'][$file_column]) && strlen(trim($data->info['row']['data'][$file_column])) >= 5) {
+        $filenames = trim($data->info['row']['data'][$file_column]);
+        $filenames = explode(';', $filenames);
+        // Clear first. Who knows whats in there. May be a file string that will eventually fail. We should not allow anything coming
+        // From the template neither.
+        // @TODO ask users.
+        $processed_metadata[$file_column] = [];
+        foreach($filenames as $filename) {
+          $file = $this->AmiUtilityService->file_get($filename);
+          if ($file) {
+            $processed_metadata[$file_column][] = $file->id();
+          }
+        }
+      }
+    }
+
     // Decode the JSON that was captured.
-    $this->persistEntity($data);
+    $this->persistEntity($data, $processed_metadata);
   }
 
   /**
-   * Saves a NODE entity from the remote data.
+   * Saves an ADO (NODE Entity).
    *
    * @param \stdClass $data
    */
-  private function persistEntity($data) {
+  private function persistEntity(\stdClass $data, array $processed_metadata) {
+
+    $op = $data->pluginconfig->op;
     //@TODO persist needs to update too.
     $existing = $this->entityTypeManager->getStorage('node')->loadByProperties(
-      ['uuid' => $data->uuid]
+      ['uuid' => $data->info['row']['uuid']]
     );
-    //@TODO make field_descriptive_metadata passed from the Configuration
-    //@TODO status, and UID should also get settings
-    //@TODO persist can be update, so that changes things.
-    // We may want to test if there is a JSON:DIFF before saving. That way
-    // WE save space and do not add extra DB inserts/updates to things that
-    // Are not changing
-    // Also Log. We need to Log a lot here, like crazy.
-    if (!$existing) {
+
+    if ($existing && $op == 'create') {
+      error_log('Sorry. You said create but there is already an Node with that UUID');
+      //@TODO log correctly
+      return;
+    }
+
+
+    if ($data->mapping->globalmapping == "custom") {
+      $property_path = $data->mapping->custommapping_settings->{$data->info['row']['type']}->bundle;
+    }
+    else {
+      $property_path = $data->mapping->globalmapping_settings->bundle;
+    }
+    $label_column = $data->adomapping->base->label;
+    $label = $processed_metadata[$label_column];
+    $property_path_split = explode(':', $property_path);
+    if (!$property_path_split || count($property_path_split) != 2 ) {
+      error_log('Sorry. Bundle/Field names are wrong');
+      //@TODO log correctly
+      return;
+    }
+    $bundle = $property_path_split[0];
+    $field_name = $property_path_split[1];
+    // JSON_ENCODE AGAIN
+    $jsonstring = json_encode($processed_metadata, JSON_PRETTY_PRINT, 50);
+
+    if ($jsonstring) {
       $nodeValues = [
-        'uuid' => $data->uuid,
-        'type' => $data->bundle,
+        'uuid' =>  $data->info['row']['uuid'],
+        'type' => $bundle,
         'status' => 1,
-        'title' => $data->label,
-        'field_descriptive_metadata' => $data->jsonmetadata,
+        'title' => $label,
+        'uid' =>  $data->info['uid'],
+        $field_name => $jsonstring
       ];
 
       /** @var \Drupal\Core\Entity\ContentEntityBase $node */
-      $node = $this->entityTypeManager->getStorage('node')->create($nodeValues);
-      $node->save();
+      try {
+        $node = $this->entityTypeManager->getStorage('node')
+          ->create($nodeValues);
+        $node->save();
+        error_log('Well well well! Ingested!');
+      }
+      catch (\Exception $exception) {
+        error_log('Ups. Something went wrong during NODE creation/Save');
+        return;
+      }
+    }
+    else {
+      error_log('Sorry last step json encoding failed while ingesting.');
+      //@TODO log correctly
+      return;
     }
   }
 }


### PR DESCRIPTION
This include a lot of new features and improvements
- When running  AmiUtilityService->preprocessAmiSet($file,$data) objects that have children get to be ingested first. This ensures we always get correct parents.
- If parents fail to ingest for some reason, we make sure we re-enqueue children twice, after that we desist
- File fetch and better and unified now. Still need to code the last piece for ZIP files
- AMI Find and replace based on webform elements is still failing on the Form building part (had some nightmares) but i will eventually get it working. The issue is that we dynamically render/extract webform elements, and the VBO form seems to have issue passing those values into the $form_state. I may want to play the the cache.